### PR TITLE
Add --separator

### DIFF
--- a/tests/test_tse.py
+++ b/tests/test_tse.py
@@ -44,7 +44,7 @@ class _TestBase(unittest.TestCase):
         env = tse.main.Env(args.statement, args.begin, args.end,
                            args.input_encoding, args.output_encoding, args.module,
                            args.module_star, args.script_file, args.inplace, args.ignore_case,
-                           [self.testfilename])
+                           args.separator, [self.testfilename])
 
         return tse.main.run(env)
 
@@ -167,6 +167,14 @@ class TestInplace(_TestBase):
         self.failUnlessEqual(open(self.testfilename + '.bak', 'rb').read(),
                              u"\N{HIRAGANA LETTER A}".encode('utf-8'))
         os.unlink(self.testfilename + '.bak')
+
+
+class TestSeparator(_TestBase):
+
+    def testSeparator(self):
+        globals = self._run(
+            ["-s", ".*", "a=L0", "-sp", "\\t"], u"A B C\tD\tE\tF")
+        self.failUnlessEqual(globals['a'], [u"A B C", u"D", u"E", u"F"])
 
 
 class TestIndent(_TestBase):

--- a/tests/test_tse.py
+++ b/tests/test_tse.py
@@ -44,7 +44,7 @@ class _TestBase(unittest.TestCase):
         env = tse.main.Env(args.statement, args.begin, args.end,
                            args.input_encoding, args.output_encoding, args.module,
                            args.module_star, args.script_file, args.inplace, args.ignore_case,
-                           args.separator, [self.testfilename])
+                           args.field_separator, [self.testfilename])
 
         return tse.main.run(env)
 
@@ -173,7 +173,7 @@ class TestSeparator(_TestBase):
 
     def testSeparator(self):
         globals = self._run(
-            ["-s", ".*", "a=L0", "-sp", "\\t"], u"A B C\tD\tE\tF")
+            ["-s", ".*", "a=L0", "-F", "\\t"], u"A B C\tD\tE\tF")
         self.failUnlessEqual(globals['a'], [u"A B C", u"D", u"E", u"F"])
 
 

--- a/tse/main.py
+++ b/tse/main.py
@@ -28,8 +28,9 @@ class Env:
     scriptfile = SCRIPTFILE
 
     def __init__(self, statement, begin, end, input_encoding, output_encoding,
-                 module, module_star, script_file, inplace, ignore_case, files):
+                 module, module_star, script_file, inplace, ignore_case, separator, files):
         self.ignore_case = ignore_case
+        self.separator = separator
 
         if statement:
             self.actions = [(self.build_re(r), self.build_code(c))
@@ -174,6 +175,7 @@ class Env:
 
 
 def _run_script(env, input, filename, globals, locals):
+    sp = env.separator and ast.literal_eval(u'u"{}"'.format(env.separator)) or None
     for lineno, line in enumerate(input, 1):
         line = line.rstrip(u"\n")
         for r, c in env.actions:
@@ -188,7 +190,7 @@ def _run_script(env, input, filename, globals, locals):
                 locals['M'] = m
 
                 locals['L'] = line
-                locals['L0'] = line.split()
+                locals['L0'] = line.split(sp)
                 for n, s in enumerate(locals['L0'], 1):
                     locals['L' + str(n)] = s
                 locals['N'] = len(locals['L0'])
@@ -342,6 +344,8 @@ def getargparser():
                         help='action invoked after input files have been exhausted.')
     parser.add_argument('--ignore-case', '-i', action='store_true',
                         help='ignore case distinctions.')
+    parser.add_argument('--separator', '-sp', action='store', type=argstr,
+                        help='separator for splitting the line.')
     parser.add_argument(
         '--inplace', action='store', type=argstr, metavar='EXTENSION',
         help='edit files in-place.')
@@ -374,7 +378,7 @@ def main():
     env = Env(
         args.statement, args.begin, args.end, args.input_encoding, args.output_encoding,
         args.module, args.module_star, args.script_file, args.inplace, args.ignore_case,
-        args.FILE)
+        args.separator, args.FILE)
     run(env)
 
 if __name__ == '__main__':

--- a/tse/main.py
+++ b/tse/main.py
@@ -28,9 +28,9 @@ class Env:
     scriptfile = SCRIPTFILE
 
     def __init__(self, statement, begin, end, input_encoding, output_encoding,
-                 module, module_star, script_file, inplace, ignore_case, separator, files):
+                 module, module_star, script_file, inplace, ignore_case, field_separator, files):
         self.ignore_case = ignore_case
-        self.separator = separator
+        self.field_separator = field_separator
 
         if statement:
             self.actions = [(self.build_re(r), self.build_code(c))
@@ -175,7 +175,7 @@ class Env:
 
 
 def _run_script(env, input, filename, globals, locals):
-    sp = env.separator and ast.literal_eval(u'u"{}"'.format(env.separator)) or None
+    fs = re.compile(env.field_separator)
     for lineno, line in enumerate(input, 1):
         line = line.rstrip(u"\n")
         for r, c in env.actions:
@@ -190,7 +190,7 @@ def _run_script(env, input, filename, globals, locals):
                 locals['M'] = m
 
                 locals['L'] = line
-                locals['L0'] = line.split(sp)
+                locals['L0'] = fs.split(line)
                 for n, s in enumerate(locals['L0'], 1):
                     locals['L' + str(n)] = s
                 locals['N'] = len(locals['L0'])
@@ -344,8 +344,9 @@ def getargparser():
                         help='action invoked after input files have been exhausted.')
     parser.add_argument('--ignore-case', '-i', action='store_true',
                         help='ignore case distinctions.')
-    parser.add_argument('--separator', '-sp', action='store', type=argstr,
-                        help='separator for splitting the line.')
+    parser.add_argument(
+        '--field-separator', '-F', action='store', type=argstr, default=r'\s+',
+        help='separator for splitting the line.')
     parser.add_argument(
         '--inplace', action='store', type=argstr, metavar='EXTENSION',
         help='edit files in-place.')
@@ -378,7 +379,7 @@ def main():
     env = Env(
         args.statement, args.begin, args.end, args.input_encoding, args.output_encoding,
         args.module, args.module_star, args.script_file, args.inplace, args.ignore_case,
-        args.separator, args.FILE)
+        args.field_separator, args.FILE)
     run(env)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR add the "--separator" option.
example:

```
$ echo -e "A B C\tD\tE" | python3 -m tse.main --separator "\t" -p ".*" -a "print(L0)"
['A B C', 'D', 'E']
```
